### PR TITLE
Align string allocation with memory allocation

### DIFF
--- a/include/libcstring.h.in
+++ b/include/libcstring.h.in
@@ -51,37 +51,13 @@ const char *libcstring_get_version(
 
 /* String allocation
  */
-#if defined( HAVE_GLIB_H )
 #define libcstring_narrow_string_allocate( size ) \
-	g_malloc( (gsize) ( sizeof( char ) * size ) )
-
-#elif defined( HAVE_MALLOC ) || defined( WINAPI )
-#define libcstring_narrow_string_allocate( size ) \
-	malloc( sizeof( char ) * size )
-
-#elif defined( WINAPI )
-#define libcstring_narrow_string_allocate( size ) \
-	HeapAlloc( GetProcessHeap(), 0, (SIZE_T) ( sizeof( char ) * size ) )
-#endif
+  (char *) memory_allocate( sizeof( char ) * ( size ) )
 
 /* String reallocation
  */
-#if defined( HAVE_GLIB_H )
 #define libcstring_narrow_string_reallocate( buffer, size ) \
-	g_realloc( (gpointer) buffer, (gsize) ( sizeof( char ) * size ) )
-
-#elif defined( HAVE_REALLOC ) || defined( WINAPI )
-#define libcstring_narrow_string_reallocate( buffer, size ) \
-	realloc( (void *) buffer, ( sizeof( char ) * size ) )
-
-#elif defined( WINAPI )
-/* HeapReAlloc does not allocate empty (NULL) buffers as realloc does
- */
-#define libcstring_narrow_string_reallocate( buffer, size ) \
-	( buffer == NULL ) ? \
-	HeapAlloc( GetProcessHeap(), 0, (SIZE_T) ( sizeof( char ) * size ) ) : \
-	HeapReAlloc( GetProcessHeap(), 0, (LPVOID) buffer, (SIZE_T) ( sizeof( char ) * size ) )
-#endif
+  (char *) memory_reallocate( string, ( sizeof( char ) * ( size ) ) )
 
 /* String length
  */
@@ -215,37 +191,13 @@ const char *libcstring_get_version(
 
 /* String allocation
  */
-#if defined( HAVE_GLIB_H )
 #define libcstring_wide_string_allocate( size ) \
-	g_malloc( (gsize) ( sizeof( wchar_t ) * size ) )
-
-#elif defined( HAVE_MALLOC ) || defined( WINAPI )
-#define libcstring_wide_string_allocate( size ) \
-	malloc( sizeof( wchar_t ) * size )
-
-#elif defined( WINAPI )
-#define libcstring_wide_string_allocate( size ) \
-	HeapAlloc( GetProcessHeap(), 0, (SIZE_T) ( sizeof( wchar_t ) * size ) )
-#endif
+  (wchar_t *) memory_allocate( sizeof( wchar_t ) * ( size ) )
 
 /* String reallocation
  */
-#if defined( HAVE_GLIB_H )
 #define libcstring_wide_string_reallocate( buffer, size ) \
-	g_realloc( (gpointer) buffer, (gsize) ( sizeof( wchar_t ) * size ) )
-
-#elif defined( HAVE_REALLOC ) || defined( WINAPI )
-#define libcstring_wide_string_reallocate( buffer, size ) \
-	realloc( (void *) buffer, ( sizeof( wchar_t ) * size ) )
-
-#elif defined( WINAPI )
-/* HeapReAlloc does not allocate empty (NULL) buffers as realloc does
- */
-#define libcstring_wide_string_reallocate( buffer, size ) \
-	( buffer == NULL ) ? \
-	HeapAlloc( GetProcessHeap(), 0, (SIZE_T) ( sizeof( wchar_t ) * size ) ) : \
-	HeapReAlloc( GetProcessHeap(), 0, (LPVOID) buffer, (SIZE_T) ( sizeof( wchar_t ) * size ) )
-#endif
+  (wchar_t *) memory_reallocate( string, ( sizeof( wchar_t ) * ( size ) ) )
 
 /* String length
  */


### PR DESCRIPTION
After allocating a string using, e.g., `libcstring_narrow_string_allocate`, it's possible to crash when deallocating that string using `memory_free`, because different allocation and deallocation functions are used.

 This patch modifies all of the libcstring allocation functions to use the corresponding functions defined in `memory.h`, which use the correct allocation/deallocation functions.


For instance:
```
/* String allocation
 */
#if defined( HAVE_GLIB_H )
#define libcstring_narrow_string_allocate( size ) \
	g_malloc( (gsize) ( sizeof( char ) * size ) )

#elif defined( HAVE_MALLOC ) || defined( WINAPI )
#define libcstring_narrow_string_allocate( size ) \
	malloc( sizeof( char ) * size )

#elif defined( WINAPI )
#define libcstring_narrow_string_allocate( size ) \
	HeapAlloc( GetProcessHeap(), 0, (SIZE_T) ( sizeof( char ) * size ) )
#endif
```
```
/* Memory free
 */
#if defined( HAVE_GLIB_H )
#define memory_free( buffer ) \
	g_free( (gpointer) buffer )

#elif defined( WINAPI )
#define memory_free( buffer ) \
	HeapFree( GetProcessHeap(), 0, (LPVOID) buffer )

#elif defined( HAVE_FREE )
#define memory_free( buffer ) \
	free( (void *) buffer )
#endif
```

If both `HAVE_MALLOC` and `WINAPI` are defined, then strings will be allocated using `malloc` and freed using `HeapFree`. On some platforms (e.g., compiling on MinGW and running on WINE), this might work, but should obviously be avoided.